### PR TITLE
Fix undefined expansion on log.vim on nvim v0.4.4

### DIFF
--- a/autoload/taskwarrior/log.vim
+++ b/autoload/taskwarrior/log.vim
@@ -1,8 +1,8 @@
 if !isdirectory(expand(g:task_log_directory))
     call mkdir(expand(g:task_log_directory), 'p')
 endif
-let s:history_file  = expand(g:task_log_directory.'/.vim_tw.history')
-let s:bookmark_file = expand(g:task_log_directory.'/.vim_tw.bookmark')
+let s:history_file  = expand(g:task_log_directory).'/.vim_tw.history'
+let s:bookmark_file = expand(g:task_log_directory).'/.vim_tw.bookmark'
 
 function! taskwarrior#log#history(action)
     if findfile(s:history_file) == ''


### PR DESCRIPTION
nvim would fait to expand and as a result the variable would be defined
to the empty string.