### PR TITLE
Shellescape new annotations

### DIFF
--- a/autoload/taskwarrior/action.vim
+++ b/autoload/taskwarrior/action.vim
@@ -126,7 +126,7 @@ function! taskwarrior#action#annotate(op)
   endif
   if a:op == 'add'
     let annotation = input('new annotation:', '', 'file')
-    call taskwarrior#system_call(uuid, ' annotate ', annotation, 'silent')
+    call taskwarrior#system_call(uuid, ' annotate ', shellescape(annotation), 'silent')
   elseif a:op == 'del'
     let annotation = input('annotation pattern to delete:')
     call taskwarrior#system_call(uuid, ' denotate ', annotation, 'silent')


### PR DESCRIPTION
Shellescape the annotation input to prevent errors when entering a
string with shell glob characters, such as question marks (?) or
asterisks (*).

The error can be observed by attempting to insert an annotation such as
"hello?world". Without the fix, the annotation simply fails to be added
to the task. You can make it more obvious as to what the underlying
issue is by changing the last argument of `system_call` from 'silent' to
'echo'.